### PR TITLE
feat(ci): add OpenCode GitHub Actions workflow with Z.ai provider

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,6 +21,15 @@ This directory contains the complete CI/CD pipeline configuration for the Claude
 | **dependency-update.yml** | Dependency Updates | Weekly, manual | ![Deps](https://github.com/${{ github.repository }}/workflows/Dependency%20Update/badge.svg) |
 | **issue-triage.yml** | Issue Automation | Issue opened/commented | ![Triage](https://github.com/${{ github.repository }}/workflows/Issue%20Triage/badge.svg) |
 
+### AI Assistant Workflows
+
+| Workflow | Purpose | Triggers | Commands |
+|----------|---------|----------|----------|
+| **claude-code.yml** | Claude Code AI Assistant | Issue/PR comments, PRs, Issues | `@claude` |
+| **opencode.yml** | OpenCode AI Assistant | Issue/PR comments | `/opencode` or `/oc` |
+
+> **Note:** AI assistant workflows are restricted to repository members, owners, and collaborators only. |
+
 ## 📋 Workflow Details
 
 ### CI Pipeline (`ci.yml`)
@@ -121,15 +130,46 @@ This directory contains the complete CI/CD pipeline configuration for the Claude
 - ✅ Common question responses
 - ✅ Context-aware help
 
+### AI Assistant Workflows
+
+#### Claude Code Assistant (`claude-code.yml`)
+
+**Purpose:** AI-powered code assistance via Anthropic Claude
+
+**Commands:** `@claude` in issues, PRs, or comments
+
+**Features:**
+- ✅ Multi-tool support (Read, Write, Edit, Bash, etc.)
+- ✅ Web search and content fetching
+- ✅ 10-turn conversation limit
+- ✅ Member-only access
+
+**Documentation:** [Claude Code Action](https://github.com/anthropics/claude-code-action)
+
+#### OpenCode Assistant (`opencode.yml`)
+
+**Purpose:** AI-powered code assistance via OpenCode with Z.ai
+
+**Commands:** `/opencode` or `/oc` in issue/PR comments
+
+**Features:**
+- ✅ GLM-4.7 model via Z.ai
+- ✅ Lightweight alternative to Claude Code
+- ✅ Member-only access
+
+**Documentation:** [OpenCode GitHub Actions Docs](https://opencode.ai/docs/github/)
+
 ## 🔧 Configuration
 
 ### Required Secrets
 
-| Secret | Purpose | Required |
-|--------|---------|----------|
-| `GITHUB_TOKEN` | GitHub API access | ✅ (Built-in) |
-| `CODECOV_TOKEN` | Coverage reporting | ⚠️ Optional |
-| `GITLEAKS_LICENSE` | Gitleaks advanced features | ⚠️ Optional |
+| Secret | Purpose | Workflow | Required |
+|--------|---------|----------|----------|
+| `GITHUB_TOKEN` | GitHub API access | All | ✅ (Built-in) |
+| `ANTHROPIC_API_KEY` | Claude Code AI assistant | claude-code.yml | ⚠️ For AI features |
+| `OPENCODE_ZAI_API_KEY` | OpenCode AI assistant | opencode.yml | ⚠️ For AI features |
+| `CODECOV_TOKEN` | Coverage reporting | ci.yml | ⚠️ Optional |
+| `GITLEAKS_LICENSE` | Gitleaks advanced features | security.yml | ⚠️ Optional |
 
 ### Environment Variables
 

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -19,11 +19,20 @@ jobs:
   claude-code:
     name: Claude Code
     runs-on: ubuntu-latest
-    # Only run when @claude is mentioned
+    # Only run when @claude is mentioned by members/collaborators
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.body || '', '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body || '', '@claude'))
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+       (github.event_name == 'pull_request' && contains(github.event.pull_request.body || '', '@claude')) ||
+       (github.event_name == 'issues' && contains(github.event.issue.body || '', '@claude'))) &&
+      (github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR' ||
+       github.event.issue.author_association == 'MEMBER' ||
+       github.event.issue.author_association == 'OWNER' ||
+       github.event.issue.author_association == 'COLLABORATOR' ||
+       github.event.pull_request.user.author_association == 'MEMBER' ||
+       github.event.pull_request.user.author_association == 'OWNER' ||
+       github.event.pull_request.user.author_association == 'COLLABORATOR')
 
     steps:
       - name: Checkout

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -8,8 +8,11 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, '/opencode')
+      (github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR') &&
+      (contains(github.event.comment.body, '/oc') ||
+       contains(github.event.comment.body, '/opencode'))
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- Add OpenCode GitHub Actions workflow file
- Configure Z.ai as AI provider with GLM-4.7 model
- Enable OpenCode interactions via `/opencode` or `/oc` commands
- Set up proper permissions for issue and PR operations

## Changes
- Created `.github/workflows/opencode.yml`
- Configured to use `OPENCODE_ZAI_API_KEY` secret
- Triggers on issue comments and PR review comments
- Follows existing CI/CD patterns in the repository

## Setup Required
After merging, add `OPENCODE_ZAI_API_KEY` to Repository Secrets in GitHub Settings.

🤖 Generated by [OpenCode](https://opencode.ai) - Big Pickle (OpenCode Zen)