### PR TITLE
ci(ci): add pre-check validation to Claude Code workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -56,7 +56,9 @@ jobs:
       - name: Run ESLint (continue on failure)
         id: lint
         run: |
-          if npm run lint 2>&1 | tee /tmp/lint.log; then
+          npm run lint 2>&1 | tee /tmp/lint.log
+          LINT_EXIT_CODE=${PIPESTATUS[0]}
+          if [ $LINT_EXIT_CODE -eq 0 ]; then
             echo "status=pass" >> $GITHUB_OUTPUT
           else
             echo "status=fail" >> $GITHUB_OUTPUT
@@ -66,7 +68,9 @@ jobs:
       - name: Check formatting (continue on failure)
         id: format
         run: |
-          if npm run format:check 2>&1 | tee /tmp/format.log; then
+          npm run format:check 2>&1 | tee /tmp/format.log
+          FORMAT_EXIT_CODE=${PIPESTATUS[0]}
+          if [ $FORMAT_EXIT_CODE -eq 0 ]; then
             echo "status=pass" >> $GITHUB_OUTPUT
           else
             echo "status=fail" >> $GITHUB_OUTPUT
@@ -87,6 +91,7 @@ jobs:
     name: Claude Code
     runs-on: ubuntu-latest
     needs: pre-check
+    if: always() && needs.pre-check.result == 'success'
 
     steps:
       - name: Checkout
@@ -127,6 +132,7 @@ jobs:
           # Added npx:* to allow running prettier for auto-fixing
           claude_args: |
             --allowedTools "Read,Write,Edit,NotebookEdit,Glob,Grep,Bash(npm:*),Bash(npx:*),Bash(git:*),Bash(node:*),TodoWrite,AskUserQuestion,WebSearch,WebFetch,mcp__web_reader__webReader"
+            # Increased from 10 to 15 to accommodate pre-check review + fixes + validation
             --max-turns 15
           # Optional: Add environment variables and instructions
           settings: |
@@ -135,7 +141,7 @@ jobs:
                 "NODE_ENV": "test",
                 "CI": "true"
               },
-              "instructions": "Before making code changes, check if there are any lint or formatting issues. Use 'npx prettier --write' to auto-fix formatting issues when appropriate. Always run tests before committing."
+              "instructions": "Before making code changes, check the LINT_STATUS and FORMAT_STATUS environment variables to understand code quality. Use 'npx prettier --write' to auto-fix formatting issues when appropriate. Always run tests before committing."
             }
         env:
           # Use custom API base URL for Z.ai


### PR DESCRIPTION
## Summary

Add a pre-check job that runs ESLint and Prettier before Claude Code executes, providing context about code quality issues to assist with auto-fixing.

## Changes

- **Pre-check job**: Runs ESLint and Prettier validation before Claude Code (continues on failure)
- **Artifacts**: Uploads lint/format logs as artifacts for debugging
- **Status passing**: Passes lint/format status to Claude via environment variables (`LINT_STATUS`, `FORMAT_STATUS`)
- **Summary display**: Shows pre-check results in workflow summary table
- **Tool permissions**: Added `npx:*` to allowed tools for prettier auto-fixing
- **Increased capacity**: Max-turns increased from 10 to 15
- **Instructions**: Added instructions for Claude to check lint/format before making changes

## Benefits

- Claude can see code quality issues before making changes
- Enables auto-fixing formatting issues via `npx prettier --write`
- Better context for AI-assisted code reviews
- Artifact retention (1 day) for debugging workflow issues

## Test Plan

- [x] Workflow syntax is valid
- [x] Pre-check job runs before Claude Code
- [x] Artifacts are uploaded correctly
- [x] Status variables are passed to Claude Code job

---

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 4.7