### PR TITLE
feat(ci): add CI status check to automated PR reviews

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -61,6 +61,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Query latest CI workflow run for this PR branch
+            // Note: workflow_id hardcoded to 'ci.yml' - update if CI workflow is renamed
             const runs = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -69,13 +71,14 @@ jobs:
               per_page: 1
             });
 
+            // Handle case where CI hasn't run yet (e.g., first-time contributor)
             const latestRun = runs.data.workflow_runs[0];
-            const status = latestRun.status === 'completed'
-              ? latestRun.conclusion
-              : 'pending';
+            const status = latestRun
+              ? (latestRun.status === 'completed' ? latestRun.conclusion : 'pending')
+              : 'not_run';
 
             core.setOutput('status', status);
-            core.setOutput('url', latestRun.html_url);
+            core.setOutput('url', latestRun?.html_url || '');
 
       - name: Run Code Review
         if: steps.filter.outputs.critical == 'true'
@@ -87,7 +90,7 @@ jobs:
             --max-turns 10
           settings: |
             {
-              "instructions": "You are a code reviewer for a PR that changes critical paths.\n\nCI Status: \"${{ steps.ci-status.outputs.status }}\"\nCI Workflow: ${{ steps.ci-status.outputs.url }}\n\nIf CI status is 'failure', this is a CRITICAL ISSUE that must be addressed.\n\nAnalyze this PR for:\n\n1. **CI Test Results** (check above - if failing, must fix)\n2. **Security Issues** (OWASP Top 10, auth flaws, injection vulnerabilities)\n3. **Code Quality** (type safety, error handling, performance)\n4. **Best Practices** (framework patterns, project conventions)\n5. **Breaking Changes** (API changes, migration requirements)\n\nFormat your response as:\n\n## 🚨 Critical Issues (must fix)\n## ⚠️ Medium/Low Issues (should fix)\n## ✅ Positive Findings\n## 📋 Recommendation\n\nFinal line must be one of:\n- `APPROVED`\n- `NEEDS_CHANGES`\n- `REVIEW_REQUIRED`",
+              "instructions": "You are a code reviewer for a PR that changes critical paths.\n\nCI Status: \"${{ steps.ci-status.outputs.status }}\"\nCI Workflow: ${{ steps.ci-status.outputs.url }}\n\nCI Status Handling:\n- 'failure': CRITICAL ISSUE - tests failing, must fix before approval\n- 'not_run': WARNING - CI hasn't run yet, recommend running tests first\n- 'pending': CI still running, review code but tests may fail\n- 'success': All tests passed, proceed with review\n\nAnalyze this PR for:\n\n1. **CI Test Results** (check above - handle based on status)\n2. **Security Issues** (OWASP Top 10, auth flaws, injection vulnerabilities)\n3. **Code Quality** (type safety, error handling, performance)\n4. **Best Practices** (framework patterns, project conventions)\n5. **Breaking Changes** (API changes, migration requirements)\n\nFormat your response as:\n\n## 🚨 Critical Issues (must fix)\n## ⚠️ Medium/Low Issues (should fix)\n## ✅ Positive Findings\n## 📋 Recommendation\n\nFinal line must be one of:\n- `APPROVED`\n- `NEEDS_CHANGES`\n- `REVIEW_REQUIRED`",
               "env": {
                 "NODE_ENV": "test",
                 "CI": "true"


### PR DESCRIPTION
## Summary
Adds lightweight CI workflow status checking to automated PR reviews, providing Claude with test results context without duplicating test runs.

## What This Does

**Before**: Claude reviewed code without knowing if tests passed
- Could approve PRs with failing tests
- No context about CI status
- Review quality limited to code analysis only

**After**: Claude gets CI status before reviewing
- Knows if tests passed/failed/pending
- Gets link to CI workflow run for investigation
- Explicitly flags CI failures as CRITICAL issues
- Better review quality with full context

## How It Works

1. **New Step**: "Check CI workflow status"
   - Queries GitHub API for latest `ci.yml` run on PR branch
   - Extracts status: `success`, `failure`, or `pending`
   - Passes status and CI workflow URL to next step

2. **Updated Claude Instructions**
   - Receives CI status as context
   - Told to flag CI failures as CRITICAL
   - Can link to CI run for investigation

## Why This Approach

### Complementary to Branch Protection
- **Branch protection**: Enforcement (prevents merging failing tests) ✅
- **This check**: Guidance (tells Claude tests failed) 📝

They serve different purposes:
- Branch protection = "Can I merge?" (binary)
- CI status check = "What should I fix?" (qualitative)

### Cost-Effective
- ✅ No duplicate test runs (just API call)
- ✅ Fast (< 1 second)
- ✅ Free (GitHub API)
- ✅ Simple to maintain

### Appropriate for Current Stage
- Recommended by [eval-002](https://github.com/shrwnsan/claude-marketplace-registry/blob/main/docs/eval-002-ci-security-and-contact-methods-20250122.md)
- Early-stage project best practice
- Easy to upgrade to full test execution later if needed

## Example Review Output

**Before**:
```
## 🚨 Critical Issues
None found

APPROVED
```

**After** (when tests fail):
```
## 🚨 Critical Issues
- CI TESTS FAILED: 3 tests failing in src/utils/validation.ts
  Link: https://github.com/.../actions/runs/123456
  MUST FIX before merge

## ⚠️ Medium/Low Issues
Consider adding error handling...

NEEDS_CHANGES
```

## Testing

The workflow will trigger on the next PR that modifies critical paths:
- `.github/workflows/**`
- `pages/api/**`
- `src/services/**`
- `src/lib/**`
- etc.

## Related

- [eval-002](https://github.com/shrwnsan/claude-marketplace-registry/blob/main/docs/eval-002-ci-security-and-contact-methods-20250122.md) - Full analysis and recommendation
- [auto-pr-review.yml](https://github.com/shrwnsan/claude-marketplace-registry/blob/main/.github/workflows/auto-pr-review.yml) - Updated workflow

---

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 4.7