### PR TITLE
test: verify Option 1 ultra-simple placeholders (PR #46)

### DIFF
--- a/test-option-1-fixes/README.md
+++ b/test-option-1-fixes/README.md
@@ -1,0 +1,13 @@
+# Test PR for Option 1 Fixes
+
+This PR tests the workflow with Option 1 changes:
+- Ultra-simple text placeholders [PASTE ... HERE]
+- No bash heredoc syntax in instructions
+- CLAUDE_JOB markers restored
+
+## Expected Results
+- Separate branded comments via gh pr comment
+- Actual JSON payloads embedded with real data
+- CLAUDE_JOB markers visible in comments
+
+


### PR DESCRIPTION
## Test PR for Option 1 Fixes

This PR tests the workflow with **Option 1** changes from PR #46:
- Ultra-simple text placeholders `[PASTE ... HERE]`
- No bash heredoc syntax in instructions
- CLAUDE_JOB markers restored (review, self-review, triage)

### Expected Results

✅ **Should work now:**
- Separate branded comments via `gh pr comment` (not just main claude-code-action ones)
- Actual JSON payloads embedded with real data (runId, prNumber, timestamp)
- CLAUDE_JOB markers visible in comments

### Previous Issues (PRs #39-45)

- Claude described JSON format instead of embedding it
- Only main claude-code-action comments (3 per run)
- No separate branded comments

### Root Cause

Claude was interpreting bash heredoc syntax in instructions as examples rather than commands to execute.

---

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 4.7

@claude please review this PR