### PR TITLE
fix(workflow): handle missing out/ directory in scan workflow

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -213,8 +213,13 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-          # Add all changes
-          git add data/ out/
+          # Add data changes (always exists)
+          git add data/
+
+          # Add build output if it exists (for static export builds)
+          if [ -d "out" ]; then
+            git add out/
+          fi
 
           # Create commit
           git commit -m "🔄 Update marketplace data - $(date '+%Y-%m-%d %H:%M:%S') [skip ci]" || echo "No changes to commit"


### PR DESCRIPTION
## Summary
- Fixed scan workflow failure when `out/` directory doesn't exist
- Added conditional check before attempting to add `out/` directory
- Workflow now works with both static export and server builds

## Context
The "Scan Marketplaces" action was failing with:
```
fatal: pathspec 'out/' did not match any files
```

This occurred because the workflow attempted to `git add out/` regardless of whether the directory existed. The project's current configuration doesn't use `output: 'export'` in `next.config.js`, so the build generates `.next/` instead of `out/`.

## Test plan
- [x] Workflow now handles missing `out/` directory gracefully
- [x] Can be tested by manually running "Scan Marketplaces" action
- [x] Works with both static export and standard Next.js builds

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 4.7