### PR TITLE
fix(workflow): add rebase before push in scan workflow

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -224,6 +224,9 @@ jobs:
           # Create commit
           git commit -m "🔄 Update marketplace data - $(date '+%Y-%m-%d %H:%M:%S') [skip ci]" || echo "No changes to commit"
 
+          # Pull rebase to handle any remote changes that occurred during workflow
+          git pull --rebase --autostash || echo "No remote changes to rebase"
+
           # Push changes
           git push
 


### PR DESCRIPTION
## Summary

- Add `git pull --rebase --autostash` before `git push` in the scan workflow
- Prevents "non-fast-forward" errors when concurrent commits occur during workflow execution

## Problem

The Scan Marketplaces workflow was failing with a push error when the remote branch had moved ahead during the workflow run:

```
! [rejected]        main -> main (non-fast-forward)
error: failed to push some refs
```

## Solution

The fix adds a rebase step before pushing:
1. Pulls any remote changes that occurred while the workflow was running
2. Replays local commits on top of the remote branch
3. Ensures a fast-forward push succeeds

## Test plan

- [x] Manual syntax validation
- [ ] Re-run "Scan Marketplaces" workflow to verify fix

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 4.7