### PR TITLE
fix(workflow): stash changes before rebase to handle unstaged files

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -213,9 +213,21 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-          # Fetch and rebase before committing to handle any remote changes
+          # Stash changes, fetch and rebase before committing to handle any remote changes
+          # Only stash if there are actual changes (avoid no-op error)
+          git diff --quiet || git stash push -m "WIP: automated data update"
+
           git fetch origin main
-          git rebase origin/main
+          # Abort and exit 1 if rebase fails (don't continue on unreconciled history)
+          if ! git rebase origin/main; then
+            git rebase --abort
+            exit 1
+          fi
+
+          # Only pop if we actually stashed something
+          if git stash list | grep -q "WIP: automated data update"; then
+            git stash pop
+          fi
 
           # Add data changes (always exists)
           git add data/


### PR DESCRIPTION
## Problem

The Scan Marketplaces workflow's `commit-changes` job fails with:
```
error: cannot rebase: You have unstaged changes.
error: Please commit or stash them.
```

This happens because the job downloads the `generated-data` artifact, which extracts files into the working directory. These files create unstaged changes that prevent `git rebase` from working.

## Solution

Stash the downloaded changes before running `git rebase`, then pop them after:
- `git stash push -m "WIP: automated data update"` - Stash changes
- `git rebase origin/main || git rebase --abort` - Rebase with abort fallback
- `git stash pop` - Restore changes

This ensures the working tree is clean during the rebase operation.

## Test Plan

- [ ] Merge this PR
- [ ] Trigger the Scan Marketplaces workflow manually
- [ ] Verify `commit-changes` job completes successfully

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 4.7