### PR TITLE
fix(workflow): use PR-based flow for scan data updates

### DIFF
--- a/.github/workflows/auto-merge-data-updates.yml
+++ b/.github/workflows/auto-merge-data-updates.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Enable auto-merge
         if: steps.verify-data-only.outputs.safe == 'true'
-        run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash
+        run: gh pr merge "${{ github.event.pull_request.html_url }}" --auto --squash --delete-branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -266,7 +266,10 @@ jobs:
           echo "Created PR: $PR_URL"
 
           # Enable auto-merge directly (works when using PAT)
-          gh pr merge "$PR_URL" --auto --squash --delete-branch
+          # Note: --delete-branch is omitted because it can fail with --auto
+          # (branch deletion only happens at merge time). Branch cleanup is
+          # handled by the auto-merge-data-updates workflow instead.
+          gh pr merge "$PR_URL" --auto --squash
 
   notify:
     name: Notify Scan Results


### PR DESCRIPTION
## Problem

The Scan Marketplaces workflow fails at the "Commit data changes directly to main" step because `main` has branch protection requiring changes via pull request:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

Ref: https://github.com/shrwnsan/claude-marketplace-registry/actions/runs/21735946912/job/62701017744

## Root Cause

The workflow used `git push origin HEAD:main` which is blocked by branch protection. Additionally, `GITHUB_TOKEN` cannot:
- Approve its own PRs (self-approval blocked)
- Trigger downstream workflows (GitHub safety mechanism)

## Solution

- **scan.yml**: Create a PR on an `automated/marketplace-data-update-*` branch instead of pushing directly to main
- **scan.yml**: Use `DATA_UPDATES_PAT` for authentication so downstream workflows trigger and PRs can be approved
- **scan.yml**: Enable auto-merge (`--squash --delete-branch`) on the created PR
- **scan.yml**: Scope change detection to `data/` only (avoids false positives from unrelated dirty files)
- **scan.yml**: Set `HUSKY=0` to skip pre-commit hooks in CI
- **auto-merge-data-updates.yml**: Add `gh pr merge --auto --squash` step after approval to complete the E2E automation loop

## Setup Required

A `DATA_UPDATES_PAT` secret must be configured (already done). Repo must have "Allow auto-merge" enabled (already done).