### PR TITLE
fix(workflow): fix workflow_run context and add guard clauses

### DIFF
--- a/.github/workflows/amp-review-tier1.yml
+++ b/.github/workflows/amp-review-tier1.yml
@@ -21,6 +21,7 @@ jobs:
       pr_number: ${{ steps.extract.outputs.pr_number }}
       author_association: ${{ steps.extract.outputs.author_association }}
       head_sha: ${{ steps.extract.outputs.head_sha }}
+      is_draft: ${{ steps.extract.outputs.is_draft }}
     steps:
       - name: Download routing artifacts
         uses: actions/download-artifact@v4
@@ -56,17 +57,20 @@ jobs:
           fi
           echo "author_association=${AUTHOR_ASSOCIATION}" >> $GITHUB_OUTPUT
 
-          # Extract PR number and head SHA from workflow_run context
+          # Extract PR details from workflow_run context
           PR_COUNT=$(jq -r '.workflow_run.pull_requests | length' "$GITHUB_EVENT_PATH")
           if [ "$PR_COUNT" -gt 0 ]; then
             PR_NUMBER=$(jq -r '.workflow_run.pull_requests[0].number' "$GITHUB_EVENT_PATH")
             HEAD_SHA=$(jq -r '.workflow_run.head_sha // ""' "$GITHUB_EVENT_PATH")
+            IS_DRAFT=$(jq -r '.workflow_run.pull_requests[0].draft // "false"' "$GITHUB_EVENT_PATH")
             echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
             echo "head_sha=${HEAD_SHA}" >> $GITHUB_OUTPUT
+            echo "is_draft=${IS_DRAFT}" >> $GITHUB_OUTPUT
           else
             echo "⚠️ No pull requests found in workflow_run event"
             echo "pr_number=0" >> $GITHUB_OUTPUT
             echo "head_sha=" >> $GITHUB_OUTPUT
+            echo "is_draft=false" >> $GITHUB_OUTPUT
           fi
 
   amp-review:
@@ -74,6 +78,7 @@ jobs:
     needs: get-tier
     # Only run for Tier 1 (fast triage)
     if: |
+      needs.get-tier.result == 'success' &&
       needs.get-tier.outputs.tier == '1' &&
       (needs.get-tier.outputs.author_association == 'OWNER' ||
        needs.get-tier.outputs.author_association == 'MEMBER' ||
@@ -145,6 +150,7 @@ jobs:
     needs: get-tier
     # Post a comment if PR doesn't qualify for Tier 1
     if: |
+      needs.get-tier.result == 'success' &&
       needs.get-tier.outputs.tier != '1' &&
       (needs.get-tier.outputs.author_association == 'OWNER' ||
        needs.get-tier.outputs.author_association == 'MEMBER' ||

--- a/.github/workflows/claude-auto-pr-review.yml
+++ b/.github/workflows/claude-auto-pr-review.yml
@@ -78,6 +78,7 @@ jobs:
     needs: get-tier
     # Only run for Tier 2 (standard) or fallback tier 2
     if: |
+      needs.get-tier.result == 'success' &&
       (needs.get-tier.outputs.tier == '2' || needs.get-tier.outputs.tier == '') &&
       (needs.get-tier.outputs.author_association == 'OWNER' ||
        needs.get-tier.outputs.author_association == 'MEMBER' ||
@@ -107,7 +108,13 @@ jobs:
         with:
           script: |
             const prNumber = parseInt('${{ needs.get-tier.outputs.pr_number }}', 10);
-            const headBranch = '${{ github.event.workflow_run.head_branch }}';
+
+            if (!prNumber || prNumber === 0) {
+              console.log('No PR number available, skipping CI status check');
+              core.setOutput('status', 'unknown');
+              core.setOutput('url', '');
+              return;
+            }
 
             // Get the PR to find the head ref
             const { data: pr } = await github.rest.pulls.get({
@@ -124,7 +131,9 @@ jobs:
               per_page: 1
             });
 
-            const latestRun = runs.data.workflow_runs[0];
+            const latestRun = runs.data.workflow_runs && runs.data.workflow_runs.length > 0
+              ? runs.data.workflow_runs[0]
+              : null;
             const status = latestRun
               ? (latestRun.status === 'completed' ? latestRun.conclusion : 'pending')
               : 'not_run';

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -73,8 +73,8 @@ jobs:
   droid-review:
     needs: get-tier
     if: |
+      needs.get-tier.result == 'success' &&
       needs.get-tier.outputs.tier == '3' &&
-      github.event.workflow_run.conclusion == 'success' &&
       needs.get-tier.outputs.is_draft == 'false' &&
       (needs.get-tier.outputs.author_association == 'OWNER' ||
        needs.get-tier.outputs.author_association == 'MEMBER' ||


### PR DESCRIPTION
## Summary

Fix all three tiered PR review workflows to properly handle `workflow_run` events and prevent false triggers from non-PR workflows like Scan Marketplaces.

## Root Cause

The tiered review workflows had two critical issues:

1. **Wrong event context access**: They referenced `github.event.pull_request.*` properties which don't exist in `workflow_run` events
2. **No guard clauses**: They would execute for ANY completed workflow named "Route PR to Model", including those triggered by non-PR events (e.g., Scan Marketplaces running on main)

## Changes

### 1. Guard Clauses
Added `if: github.event.workflow_run.event == 'pull_request'` to `get-tier` jobs in all three workflows:
- `amp-review-tier1.yml`
- `droid-review.yml`  
- `claude-auto-pr-review.yml`

This prevents the workflows from running when triggered by non-PR events.

### 2. Event Context Fixes
- Extract `pr_number`, `author_association`, `head_sha`, `is_draft` from `workflow_run.pull_requests[]` array
- Extract `author_association` from `routing-analysis.json` artifact (Route PR to Model saves this)
- Add job outputs to propagate PR data to dependent jobs
- Replace all `github.event.pull_request.*` references with `needs.get-tier.outputs.*`

### 3. YAML Syntax Fixes
- Step names with `:` and `()` confused the YAML parser
- Renamed "Run Amp Code Review (Tier 1: Fast Triage)" → "Run Amp Code Review - Tier 1 Fast Triage"
- Renamed "Run Droid Auto Review (Tier 3: Deep Analysis)" → "Run Droid Auto Review - Tier 3 Deep Analysis"

## Test Plan

- [x] YAML syntax validates for all three workflows
- [ ] Test with a real PR to verify workflows trigger correctly
- [ ] Verify Scan Marketplaces workflow no longer triggers review workflows

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 4.7