### PR TITLE
fix(ci): make pipeline sequential to fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
+    needs: [lint, test]
 
     steps:
       - name: Checkout code
@@ -136,6 +137,7 @@ jobs:
   scan-test:
     name: Test Scan Scripts
     runs-on: ubuntu-latest
+    needs: [lint, test]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Change

Gate all CI jobs behind lint+test (the fastest/cheapest checks) to fail fast and save runner minutes, while keeping the remaining jobs parallel for faster feedback.

### Before
```
lint + test ──────────────┬── build ── summary
security (independent)  ──┘
scan-test (independent) ──┘
```
Security Audit and Test Scan Scripts ran independently — wasting minutes if lint/test failed.

### After
```
lint + test ──┬── build ────────┬── summary
              ├── security ─────┤
              └── scan-test ────┘
```
All three jobs wait for lint+test, then run in parallel. Best of both worlds: fail-fast savings without delaying build feedback behind the 2m+ security scan.

Reviewed by: [Amp Code](https://ampcode.com) — Claude Opus 4.6 (Smart mode)
