### PR TITLE
fix(workflow): fix broken echo in scan summary step

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -227,7 +227,9 @@ jobs:
 
       - name: Summary
         if: steps.create-pr.outputs.pull-request-number
-        run: echo "Created/updated PR #${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: echo "Created/updated PR #${PR_NUMBER}"
 
   notify:
     name: Notify Scan Results


### PR DESCRIPTION
The `Summary` step in the scan workflow fails with `unexpected EOF while looking for matching double quote` because the PR number output is interpolated directly into the shell command. Passes it via `env` instead.