### PR TITLE
fix(workflow): fix auto-merge trigger and summary echo

### DIFF
--- a/.github/workflows/auto-merge-data-updates.yml
+++ b/.github/workflows/auto-merge-data-updates.yml
@@ -14,7 +14,7 @@ jobs:
     name: Auto-approve Data Update PRs
     runs-on: ubuntu-latest
     if: |
-      github.actor == 'github-actions[bot]' &&
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
       startsWith(github.head_ref, 'automated/marketplace-data-update')
 
     steps:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -229,7 +229,8 @@ jobs:
         if: steps.create-pr.outputs.pull-request-number
         env:
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
-        run: echo "Created/updated PR #${PR_NUMBER}"
+        run: |
+          echo "Created/updated PR number: ${PR_NUMBER}"
 
   notify:
     name: Notify Scan Results


### PR DESCRIPTION
## Summary
- Fix auto-merge workflow not triggering on automated PRs
- Fix shell parsing error in scan summary step

## Changes

### Auto-merge trigger fix
Changed `github.actor` to `github.event.pull_request.user.login` in the if condition.

**Problem:** When `peter-evans/create-pull-request` creates a PR using `secrets.GITHUB_TOKEN`, the `pull_request` event's `github.actor` is the user who triggered the workflow (e.g., `shrwnsan` for manual dispatch), not `github-actions[bot]`. However, the PR author (`github.event.pull_request.user.login`) is correctly set to `github-actions[bot]`.

### Summary echo fix
Changed single-line echo to multi-line run block to avoid shell parsing issues with variable interpolation.

## Test Plan
- [x] Merge this PR
- [x] Close PR #79
- [x] Re-run Scan Marketplaces workflow
- [ ] Verify auto-merge workflow triggers on the new PR

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5