### PR TITLE
fix(workflow): use DATA_UPDATES_PAT to trigger auto-merge on data PRs

### DIFF
--- a/.github/workflows/auto-merge-data-updates.yml
+++ b/.github/workflows/auto-merge-data-updates.yml
@@ -13,9 +13,7 @@ jobs:
   auto-approve-data-updates:
     name: Auto-approve Data Update PRs
     runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.user.login == 'github-actions[bot]' &&
-      startsWith(github.head_ref, 'automated/marketplace-data-update')
+    if: startsWith(github.head_ref, 'automated/marketplace-data-update')
 
     steps:
       - name: Checkout code

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -197,7 +197,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         id: create-pr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DATA_UPDATES_PAT }}
           commit-message: |
             🔄 Update marketplace data
 


### PR DESCRIPTION
## Changes

- **scan.yml**: Use `DATA_UPDATES_PAT` instead of `GITHUB_TOKEN` in `create-pull-request` step so the PR event triggers downstream workflows
- **auto-merge-data-updates.yml**: Remove `github-actions[bot]` author check (PAT creates PRs as the token owner, not the bot). The branch name check + data-only file verification remain as security gates.

## Why

`GITHUB_TOKEN`-created PRs don't trigger `pull_request` workflows (GitHub's recursive workflow prevention). This is why auto-merge has never fired for scan PRs despite 27 workflow runs.