### PR TITLE
fix: remove deprecated github-token parameter from download-artifact@v4

### DIFF
--- a/.github/workflows/amp-review-tier1.yml
+++ b/.github/workflows/amp-review-tier1.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: routing-analysis
-          github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Extract tier and PR number

--- a/.github/workflows/claude-auto-pr-review.yml
+++ b/.github/workflows/claude-auto-pr-review.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: routing-analysis
-          github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Extract tier and reason

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: routing-analysis
-          github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Extract tier


### PR DESCRIPTION
## Problem
The `github-token` parameter was removed in `actions/download-artifact@v4`. This was causing `get-tier` step failures in all three review tier workflows.

## Solution
Removed the deprecated `github-token` parameter from all three workflows. Authentication is now handled automatically by the action.

## Affected Workflows
- amp-review-tier1.yml
- claude-auto-pr-review.yml  
- droid-review.yml

## Testing
CI checks will validate that artifact downloads work correctly across workflows.