### PR TITLE
fix: security audit logic bug and deploy dependency chain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,7 @@ jobs:
     name: Build and Deploy
     runs-on: ubuntu-latest
     needs: [scan]
+    if: ${{ always() && (needs.scan.result == 'success' || needs.scan.result == 'skipped') }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,8 +41,11 @@ jobs:
       - name: Run npm audit
         id: audit
         run: |
-          npm audit --audit-level=moderate --json > audit-results.json || echo "vulnerabilities_found=true" >> $GITHUB_OUTPUT
-          echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT
+          if npm audit --audit-level=moderate --json > audit-results.json; then
+            echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT
+          else
+            echo "vulnerabilities_found=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Parse audit results
         id: parse

--- a/docs/plans/eval-004-github-actions-workflow-optimization.md
+++ b/docs/plans/eval-004-github-actions-workflow-optimization.md
@@ -9,13 +9,13 @@
 
 **Issue:** Each job runs `npm ci` independently, re-installing dependencies multiple times per workflow.
 
-**Impact:** 
-- 3-5 minutes wasted per job × 5-8 jobs = 15-40 minutes total per CI run
-- Even with npm cache, the install step is slow
+**Impact:**
+- ~30-60 seconds per job × 5 jobs = ~5 minutes total per CI run
+- ⚠️ **Note:** Original estimate of "3-5 min per job / 20+ min total" was overstated. All workflows already use `actions/setup-node` with `cache: 'npm'`, which caches the npm download cache. The actual overhead is the `node_modules/` extraction step, not full downloads.
 
 **Recommendation:**
 ```yaml
-# Option A: Cache the node_modules directory explicitly
+# Option A: Cache the node_modules directory explicitly (bigger win but has correctness tradeoffs)
 - uses: actions/cache@v4
   with:
     path: node_modules
@@ -31,23 +31,24 @@
     cache-dependency-path: package-lock.json  # Be explicit
 ```
 
-**Priority:** HIGH - Could save 20+ minutes per CI run
+**Priority:** MEDIUM - Could save ~5 minutes per CI run (downgraded from HIGH)
 
 ---
 
-#### 2. **Security Audit Logic Bug** 
+#### 2. **Security Audit Logic Bug** ✅ FIXED
 **File:** `security.yml` (lines 42-45)
 
 **Issue:**
 ```yaml
+# BEFORE (broken):
 run: |
   npm audit --audit-level=moderate --json > audit-results.json || echo "vulnerabilities_found=true" >> $GITHUB_OUTPUT
   echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT  # ❌ This always overwrites to false!
 ```
 
-The second echo always overwrites the first, so `vulnerabilities_found` is **always false**.
+The second echo always overwrites the first, so `vulnerabilities_found` is **always false**. This silently broke the issue-creation gate (line 59) and PR security comments (line 135). This is an **original defect** (not a regression) — the logic was never correct.
 
-**Fix:**
+**Fix applied:**
 ```yaml
 run: |
   if npm audit --audit-level=moderate --json > audit-results.json; then
@@ -58,27 +59,28 @@ run: |
 ```
 
 **Priority:** HIGH - Security alerts won't trigger properly
+**Status:** ✅ Fixed (2026-02-21)
 
 ---
 
-#### 3. **Deploy Workflow Dependency Issue**
-**File:** `deploy.yml` (lines 67)
+#### 3. **Deploy Workflow Dependency Issue** ✅ FIXED
+**File:** `deploy.yml` (line 67)
 
-**Issue:** Build job has `needs: [scan]`, but scan is optional (`if:` condition).
+**Issue:** Build job has `needs: [scan]`, but scan is optional (`if: github.event.inputs.scan_before_deploy == 'true'`).
 
-If scan is skipped, build job will still wait for it but scan won't run, causing unclear failures.
+⚠️ **Severity was underestimated.** On `push` events (the primary deploy trigger), `github.event.inputs` is null, so `scan` is always skipped → `build` is silently skipped → `deploy` is silently skipped → **the deploy workflow never deploys on push to main**. This is not just "confusing failures" — it's a fundamentally broken deploy pipeline for its primary trigger.
 
-**Fix:**
+**Fix applied:**
 ```yaml
 build:
-  needs: scan
-  if: |
-    (github.event.inputs.scan_before_deploy == 'false' || 
-     needs.scan.result == 'success' ||
-     needs.scan.result == 'skipped')
+  needs: [scan]
+  if: ${{ always() && (needs.scan.result == 'success' || needs.scan.result == 'skipped') }}
 ```
 
-**Priority:** HIGH - Can cause confusing job dependency failures
+This ensures `build` runs when `scan` succeeds or is skipped, but still blocks if `scan` explicitly fails.
+
+**Priority:** HIGH (CRITICAL) - Deploy pipeline broken on push to main
+**Status:** ✅ Fixed (2026-02-21)
 
 ---
 
@@ -140,7 +142,7 @@ concurrency:
 #### 7. **API Rate Limiting Risk**
 **Files:** `scan.yml` (GitHub API calls), `route-pr-to-model.yml`
 
-**Issue:** 
+**Issue:**
 - Scan runs daily + can be triggered manually = potential rate limit issues
 - No exponential backoff configured for retries
 
@@ -154,6 +156,8 @@ concurrency:
     RETRY_DELAY: 5  # seconds
     BACKOFF_MULTIPLIER: 2
 ```
+
+⚠️ **Review note:** The env vars above (`MAX_RETRIES`, `RETRY_DELAY`, `BACKOFF_MULTIPLIER`) are no-ops unless the scan scripts are updated to read and act on them. This recommendation requires **both** workflow and application code changes to be effective.
 
 **Priority:** MEDIUM - Could cause scan failures
 
@@ -198,6 +202,8 @@ jobs:
           [[ -n "${{ secrets.DATA_UPDATES_PAT }}" ]] || (echo "DATA_UPDATES_PAT missing" && exit 1)
 ```
 
+⚠️ **Review note:** The recommended approach is an **anti-pattern** — `${{ secrets.X }}` expands the secret value into the shell script text. Prefer job-level `if: secrets.DATA_UPDATES_PAT != ''` conditions instead. Also, `GITHUB_TOKEN` is auto-provided by GitHub Actions and never needs validation.
+
 **Priority:** LOW - Nice to have
 
 ---
@@ -221,34 +227,37 @@ Add comments to expensive operations:
 
 ## Summary Table
 
-| Issue | File | Severity | Impact | Fix Time |
-|-------|------|----------|--------|----------|
-| npm ci duplication | ci.yml, security.yml, deploy.yml | HIGH | 20+ min/run | 15 min |
-| Security audit logic bug | security.yml | HIGH | Broken alerts | 5 min |
-| Deploy dependency | deploy.yml | HIGH | Job failures | 10 min |
-| Timeout inconsistency | *-review.yml | MEDIUM | Timeout errors | 10 min |
-| Artifact retention | multiple | MEDIUM | Poor debugging | 5 min |
-| No CI concurrency | ci.yml | MEDIUM | Resource waste | 5 min |
-| Rate limiting | scan.yml | MEDIUM | Scan failures | 20 min |
-| Logging/continue-on-error | security.yml | LOW | Unclear failures | 10 min |
-| No secret validation | multiple | LOW | Late failure detection | 15 min |
-| Cost markers | droid-review.yml | LOW | Documentation | 5 min |
+| Issue | File | Severity | Impact | Fix Time | Status |
+|-------|------|----------|--------|----------|--------|
+| npm ci duplication | ci.yml, security.yml, deploy.yml | MEDIUM | ~5 min/run | 15 min | 📋 Open |
+| Security audit logic bug | security.yml | HIGH | Broken alerts | 5 min | ✅ Fixed |
+| Deploy dependency | deploy.yml | CRITICAL | Deploy broken on push | 10 min | ✅ Fixed |
+| Timeout inconsistency | *-review.yml | MEDIUM | Timeout errors | 10 min | 📋 Open |
+| Artifact retention | multiple | MEDIUM | Poor debugging | 5 min | 📋 Open |
+| No CI concurrency | ci.yml | MEDIUM | Resource waste | 5 min | 📋 Open |
+| Rate limiting | scan.yml | MEDIUM | Scan failures | 20 min | 📋 Open (needs code changes too) |
+| Logging/continue-on-error | security.yml | LOW | Unclear failures | 10 min | 📋 Open |
+| No secret validation | multiple | LOW | Late failure detection | 15 min | ⚠️ Open (anti-pattern in recommendation) |
+| Cost markers | droid-review.yml | LOW | Documentation | 5 min | 📋 Open |
 
 ## Recommended Implementation Order
 
-1. **Fix security audit logic** (5 min) - Immediate impact
-2. **Fix deploy job dependency** (10 min) - Prevents failures
-3. **Add npm caching optimization** (15 min) - Biggest perf gain
+1. ~~**Fix security audit logic** (5 min) - Immediate impact~~ ✅ Done
+2. ~~**Fix deploy job dependency** (10 min) - Prevents failures~~ ✅ Done
+3. **Add npm caching optimization** (15 min) - Moderate perf gain (~5 min/run)
 4. **Fix CI concurrency** (5 min) - Prevents waste
 5. **Adjust artifact retention** (5 min) - Better debugging
 6. **Improve timeout configs** (10 min) - Prevent timeouts
-7. **Add rate limit handling** (20 min) - Robustness
-8. **Others** (10-20 min) - Polish
+7. **Add rate limit handling** (20 min) - Requires workflow + application code changes
+8. **Others** (10-20 min) - Polish (note: #9 secret validation needs revised approach)
 
-**Total estimated time: ~90 minutes for all fixes**
+**Total estimated time: ~75 minutes for remaining fixes**
 
-**Expected outcome:** 
-- ✅ 20+ min faster CI runs
-- ✅ Security alerts work properly
-- ✅ No more mysterious job failures
+**Progress:**
+- ✅ Security alerts now trigger correctly (was silently broken since creation)
+- ✅ Deploy pipeline now works on push to main (was completely non-functional)
+
+**Expected outcome for remaining fixes:**
+- ✅ ~5 min faster CI runs
 - ✅ Better error handling & debugging
+- ✅ Reduced CI minute waste via concurrency control

--- a/docs/plans/eval-005-workflow-optimization-comparison.md
+++ b/docs/plans/eval-005-workflow-optimization-comparison.md
@@ -14,7 +14,8 @@
 
 **Current Evaluation (eval-004)**: Focuses on **performance optimization & hidden bugs** — workflows running but suboptimal
 - ⚠️ Identified 10 new optimization/reliability issues
-- Found 1 regression (security audit logic bug that was never fixed)
+- Found 1 original defect (security audit logic bug — never worked correctly, not a regression)
+- 2 critical issues fixed (security audit logic, deploy dependency)
 
 **Key Difference**: eval-001 fixed **blocking issues**. eval-004 addresses **efficiency & correctness issues** that don't break workflows but harm performance and reliability.
 
@@ -26,9 +27,9 @@
 
 | Issue | Severity | Root Cause | Status in eval-001 |
 |-------|----------|-----------|-------------------|
-| **npm ci duplication** | HIGH | Each job re-installs deps | Not mentioned |
-| **Security audit logic bug** | HIGH | Always overwrites check to false | Not mentioned |
-| **Deploy job dependency** | HIGH | Optional scan breaks build chain | Not mentioned |
+| **npm ci duplication** | MEDIUM | Each job re-installs deps (~5 min, not 20+) | Not mentioned |
+| **Security audit logic bug** | HIGH | Always overwrites check to false | Not mentioned | ✅ Fixed |
+| **Deploy job dependency** | CRITICAL | Scan skip → build skip → **deploy never runs on push** | Not mentioned | ✅ Fixed |
 
 ### 🟡 Medium Priority - Reliability & Operations
 
@@ -66,19 +67,29 @@ These were critical **failures** - workflows not running at all:
 
 ---
 
-## Regression Found: Security Audit Logic Bug
+## Original Defect Found: Security Audit Logic Bug ✅ FIXED
+
+> **Terminology correction:** This was originally labeled a "regression," but it is an **original defect** — the logic was never correct. A regression implies something worked before and then broke; this never worked.
 
 ### Details
 
-**File**: `security.yml` (lines 42-45)  
-**Severity**: HIGH  
-**Status**: NOT in eval-001 ❌
+**File**: `security.yml` (lines 42-45)
+**Severity**: HIGH
+**Status**: ✅ Fixed (2026-02-21)
 
 ```yaml
-# Current broken code:
+# BEFORE (broken):
 run: |
   npm audit --audit-level=moderate --json > audit-results.json || echo "vulnerabilities_found=true" >> $GITHUB_OUTPUT
   echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT  # ❌ Always overwrites!
+
+# AFTER (fixed):
+run: |
+  if npm audit --audit-level=moderate --json > audit-results.json; then
+    echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT
+  else
+    echo "vulnerabilities_found=true" >> $GITHUB_OUTPUT
+  fi
 ```
 
 ### Why Missed in eval-001?
@@ -106,7 +117,7 @@ eval-001 was focused on **"Is the workflow running?"**
 eval-004 asks **"Is the workflow running efficiently?"**
 
 **Examples:**
-- npm ci duplication: Workflows **work fine**, but waste 20+ minutes
+- npm ci duplication: Workflows **work fine**, but waste ~5 minutes (originally estimated at 20+, but `cache: 'npm'` is already configured)
 - Artifact retention: Workflows **work fine**, but debugging is harder
 - Timeouts: Workflows **work fine**, until they don't (timeout edge case)
 
@@ -137,20 +148,20 @@ External Reliability → Cascading failures (no retry backoff)
 
 ## Recommendation: Implementation Priority
 
-**Phase 1 (Critical - Breaks Functionality)**
-1. ✅ Fix security audit logic bug (eval-004 #2) — 5 min
-2. ✅ Fix deploy job dependency (eval-004 #3) — 10 min
-3. ✅ Add npm caching (eval-004 #1) — 15 min
+**Phase 1 (Critical - Breaks Functionality)** ✅ COMPLETE
+1. ✅ ~~Fix security audit logic bug (eval-004 #2) — 5 min~~ Fixed (2026-02-21)
+2. ✅ ~~Fix deploy job dependency (eval-004 #3) — 10 min~~ Fixed (2026-02-21)
+3. 📋 Add npm caching (eval-004 #1) — 15 min (impact revised: ~5 min savings, not 20+)
 
 **Phase 2 (Important - Improves Reliability)**
-4. ✅ Fix CI concurrency (eval-004 #6) — 5 min
-5. ✅ Adjust artifact retention (eval-004 #5) — 5 min
-6. ✅ Improve timeout configs (eval-004 #4) — 10 min
-7. ✅ Add rate limit handling (eval-004 #7) — 20 min
+4. 📋 Fix CI concurrency (eval-004 #6) — 5 min
+5. 📋 Adjust artifact retention (eval-004 #5) — 5 min
+6. 📋 Improve timeout configs (eval-004 #4) — 10 min
+7. 📋 Add rate limit handling (eval-004 #7) — 20 min (requires app code changes, not just workflow config)
 
 **Phase 3 (Nice to Have - Improves Visibility)**
-8. ⚠️ Improve logging (eval-004 #8) — 10 min
-9. ⚠️ Add secret validation (eval-004 #9) — 15 min
+8. 📋 Improve logging (eval-004 #8) — 10 min
+9. ⚠️ Add secret validation (eval-004 #9) — 15 min (recommendation needs revision: anti-pattern)
 10. 📝 Cost documentation (eval-004 #10) — 5 min
 
 ---
@@ -164,13 +175,13 @@ External Reliability → Cascading failures (no retry backoff)
 - `issue-triage.yml` - YAML parsing
 - Various - Node version standardization
 
-### eval-004 (To Be Fixed)
-- `ci.yml` - Add npm caching, concurrency
-- `security.yml` - Fix audit logic, improve logging
-- `deploy.yml` - Fix job dependency chain
-- `scan.yml` - Add rate limiting
-- `*-review.yml` - Adjust timeouts (3 files)
-- All files - Adjust artifact retention
+### eval-004 (Partial — 2 of 10 fixed)
+- `security.yml` - ✅ Fixed audit logic; logging improvement still open
+- `deploy.yml` - ✅ Fixed job dependency chain
+- `ci.yml` - 📋 Add npm caching, concurrency (open)
+- `scan.yml` - 📋 Add rate limiting (open; requires app code changes)
+- `*-review.yml` - 📋 Adjust timeouts (open; 3 files)
+- All files - 📋 Adjust artifact retention (open)
 
 ---
 
@@ -179,17 +190,18 @@ External Reliability → Cascading failures (no retry backoff)
 | Period | Focus | Issue Type | Count | Status |
 |--------|-------|-----------|-------|--------|
 | **eval-001** (2025-01-17) | Operational Failures | Blocking issues | 8 | ✅ Fixed |
-| **eval-004** (2026-02-21) | Performance Optimization | Efficiency issues | 10 | 📋 Identified |
-| **Next Phase** | Implementation | Mixed priority | 10 | ⏳ Pending |
+| **eval-004** (2026-02-21) | Performance Optimization | Efficiency issues | 10 | 2 ✅ Fixed, 8 📋 Open |
+| **Next Phase** | Implementation | Mixed priority | 8 | ⏳ Pending |
 
 ---
 
 ## Key Insights
 
-1. **eval-001 was comprehensive** for operational failures - didn't miss blocking issues
-2. **Security audit logic bug is a regression**, not a previous miss - the logic was never tested for correctness
-3. **Performance issues require different evaluation criteria** than operational failures
-4. **Both evaluations are valuable** - they answer different questions:
+1. **eval-001 was comprehensive** for operational failures — didn't miss blocking issues
+2. **Security audit logic bug is an original defect**, not a regression — the logic was never correct, it was never tested for correctness
+3. **Deploy dependency was more severe than initially assessed** — not just "confusing failures" but a completely broken deploy pipeline on push to main
+4. **Performance impact claims need code-level verification** — npm ci duplication impact was overstated (5 min, not 20+), rate limit env vars are no-ops without app code changes, and secret validation recommendation contains an anti-pattern
+5. **Both evaluations are valuable** — they answer different questions:
    - eval-001: "Does it work?"
    - eval-004: "Does it work well?"
 
@@ -200,9 +212,10 @@ External Reliability → Cascading failures (no retry backoff)
 | Category | eval-001 | eval-004 |
 |----------|----------|----------|
 | **Scope** | Operational failures | Performance optimization |
-| **Issues Found** | 8 critical | 10 mixed priority |
-| **Status** | ✅ All fixed | 📋 Identified, awaiting fix |
-| **Regression** | N/A | 1 logic bug not caught before |
-| **Next Action** | ✅ Complete | Implement fixes in 3 phases |
+| **Issues Found** | 8 critical | 10 mixed priority (1 CRITICAL, 1 HIGH, 5 MEDIUM, 3 LOW) |
+| **Status** | ✅ All fixed | 2 ✅ Fixed, 8 📋 Open |
+| **Defects** | N/A | 1 original defect (security audit), 1 critical deploy bug |
+| **Review Notes** | N/A | 3 recommendations need revision (#1 impact, #7 incomplete, #9 anti-pattern) |
+| **Next Action** | ✅ Complete | Implement remaining 8 fixes in 2 phases |
 
-The project went from **non-functional workflows** (eval-001) to **functional but inefficient workflows** (eval-004). Next step is to optimize for **performance and reliability** while maintaining the operational stability eval-001 achieved.
+The project went from **non-functional workflows** (eval-001) to **functional but inefficient workflows** (eval-004). The two most critical issues (security audit logic and deploy pipeline) are now fixed. Next step is to optimize for **performance and reliability** while maintaining the operational stability achieved.


### PR DESCRIPTION
## Summary

Fixes two critical workflow bugs identified in eval-004/eval-005 reviews.

### Fix 1: Security Audit Logic Bug (`security.yml`)
The `vulnerabilities_found` output was **always overwritten to `false`** due to a second unconditional `echo` after the conditional one. Security issue creation (line 59) and PR comments (line 135) never triggered.

**Before:**
```yaml
npm audit ... || echo "vulnerabilities_found=true" >> $GITHUB_OUTPUT
echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT  # ❌ always runs
```

**After:** Proper if/else so only one value is written.

### Fix 2: Deploy Dependency Chain (`deploy.yml`)
`build` job had `needs: [scan]`, but `scan` is conditional (`scan_before_deploy == 'true'`). On `push` events (the primary trigger), `scan` is always skipped → `build` is silently skipped → **nothing ever deploys on push to main**.

**Fix:** Added `if: ${{ always() && (needs.scan.result == 'success' || needs.scan.result == 'skipped') }}` to the build job.

### Documentation Updates
- Updated eval-004 and eval-005 with fix statuses, corrected severity ratings
- Downgraded npm ci duplication impact (MEDIUM, ~5 min not 20+)
- Added review notes on rate limiting no-op and secret validation anti-pattern
- Corrected "regression" → "original defect" terminology for security bug

## Verification After Merge
1. **Deploy fix**: The merge push itself triggers `deploy.yml` — verify `build` job runs instead of being skipped
2. **Security fix**: Trigger manually via Actions → Security Scan → Run workflow, or wait for weekly schedule — verify `vulnerabilities_found` output matches actual audit result

Reviewed by: [Amp Code](https://ampcode.com) — Claude Opus 4.6 (Smart mode)