### PR TITLE
docs: update GitHub Pages URLs and clarify deployment status

### DIFF
--- a/docs/guides/MAINTENANCE_GUIDE.md
+++ b/docs/guides/MAINTENANCE_GUIDE.md
@@ -27,25 +27,25 @@ This comprehensive guide provides maintenance procedures, troubleshooting steps,
 
 **Website Accessibility**:
 ```bash
-curl -I https://claude-marketplace.github.io/aggregator
+curl -I https://shrwnsan.github.io/claude-marketplace-registry
 # Expected: 200 OK response
 ```
 
 **Health Endpoint Status**:
 ```bash
-curl https://claude-marketplace.github.io/aggregator/data/health.json
+curl https://shrwnsan.github.io/claude-marketplace-registry/data/health.json
 # Verify status is "healthy"
 ```
 
 **Data Freshness**:
 ```bash
-curl https://claude-marketplace.github.io/aggregator/data/status.json | jq '.lastUpdated'
+curl https://shrwnsan.github.io/claude-marketplace-registry/data/status.json | jq '.lastUpdated'
 # Expected: Recent timestamp (less than 6 hours old)
 ```
 
 **System Status**:
 ```bash
-curl https://claude-marketplace.github.io/aggregator/data/status.json
+curl https://shrwnsan.github.io/claude-marketplace-registry/data/status.json
 # Verify all systems show "operational" status
 ```
 
@@ -257,7 +257,7 @@ GET /api/status
 **Commands**:
 ```bash
 # Check deployment status
-curl -I https://claude-marketplace.github.io/aggregator
+curl -I https://shrwnsan.github.io/claude-marketplace-registry
 
 # Check DNS resolution
 nslookup claude-marketplace.github.io
@@ -283,7 +283,7 @@ openssl s_client -connect claude-marketplace.github.io:443
 **Commands**:
 ```bash
 # Check GitHub API status
-curl https://claude-marketplace.github.io/aggregator/api/status
+curl https://shrwnsan.github.io/claude-marketplace-registry/api/status
 
 # Manually trigger scan
 gh workflow run scan.yml
@@ -309,10 +309,10 @@ gh run list --workflow=scan.yml
 **Commands**:
 ```bash
 # Check performance metrics
-curl https://claude-marketplace.github.io/aggregator/api/metrics
+curl https://shrwnsan.github.io/claude-marketplace-registry/api/metrics
 
 # Analyze page load
-lighthouse https://claude-marketplace.github.io/aggregator --output=json
+lighthouse https://shrwnsan.github.io/claude-marketplace-registry --output=json
 
 # Check data file sizes
 du -sh data/*.json
@@ -432,10 +432,10 @@ gh run view <run-id> --job=<job-id>
 npm run build -- --analyze
 
 # Check performance metrics
-curl https://claude-marketplace.github.io/aggregator/api/metrics
+curl https://shrwnsan.github.io/claude-marketplace-registry/api/metrics
 
 # Run Lighthouse audit
-lighthouse https://claude-marketplace.github.io/aggregator
+lighthouse https://shrwnsan.github.io/claude-marketplace-registry
 
 # Monitor resource usage
 npm run dev -- --profile
@@ -599,7 +599,7 @@ echo "=== System Health Check ==="
 echo "Time: $(date)"
 
 # Check website accessibility
-if curl -f -s https://claude-marketplace.github.io/aggregator > /dev/null; then
+if curl -f -s https://shrwnsan.github.io/claude-marketplace-registry > /dev/null; then
     echo "✅ Website accessible"
 else
     echo "❌ Website not accessible"
@@ -607,7 +607,7 @@ else
 fi
 
 # Check API health
-health_response=$(curl -s https://claude-marketplace.github.io/aggregator/api/health)
+health_response=$(curl -s https://shrwnsan.github.io/claude-marketplace-registry/api/health)
 if echo "$health_response" | grep -q '"status":"healthy"'; then
     echo "✅ API healthy"
 else
@@ -617,7 +617,7 @@ else
 fi
 
 # Check data freshness
-data_age=$(curl -s https://claude-marketplace.github.io/aggregator/api/status | jq -r '.systems.data.dataFreshness')
+data_age=$(curl -s https://shrwnsan.github.io/claude-marketplace-registry/api/status | jq -r '.systems.data.dataFreshness')
 if [[ "$data_age" == *"hour"* ]] && [[ $(echo "$data_age" | cut -d' ' -f1) -lt 6 ]]; then
     echo "✅ Data fresh ($data_age)"
 else
@@ -637,7 +637,7 @@ echo "Time: $(date)"
 
 # Check page load time
 start_time=$(date +%s%N)
-curl -s https://claude-marketplace.github.io/aggregator > /dev/null
+curl -s https://shrwnsan.github.io/claude-marketplace-registry > /dev/null
 end_time=$(date +%s%N)
 load_time=$(( (end_time - start_time) / 1000000 ))
 
@@ -653,7 +653,7 @@ fi
 
 # Check API response time
 start_time=$(date +%s%N)
-curl -s https://claude-marketplace.github.io/aggregator/api/health > /dev/null
+curl -s https://shrwnsan.github.io/claude-marketplace-registry/api/health > /dev/null
 end_time=$(date +%s%N)
 api_time=$(( (end_time - start_time) / 1000000 ))
 

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -21,7 +21,7 @@ The Claude Marketplace Aggregator is a comprehensive platform that discovers, cu
 
 ### Accessing the Platform
 
-1. **Visit the Website**: Navigate to [claude-marketplace.github.io/aggregator](https://claude-marketplace.github.io/aggregator)
+1. **Visit the Website**: Navigate to [shrwnsan.github.io/claude-marketplace-registry](https://shrwnsan.github.io/claude-marketplace-registry)
 2. **Explore the Homepage**: Get an overview of the ecosystem with statistics and featured content
 3. **Use the Search Bar**: Find specific plugins or marketplaces
 4. **Browse Categories**: Explore content organized by functionality
@@ -282,10 +282,10 @@ interface OverviewStats {
 #### API Access
 ```bash
 # Get analytics data
-curl https://claude-marketplace.github.io/aggregator/api/analytics
+curl https://shrwnsan.github.io/claude-marketplace-registry/api/analytics
 
 # Get specific metrics
-curl https://claude-marketplace.github.io/aggregator/api/metrics
+curl https://shrwnsan.github.io/claude-marketplace-registry/api/metrics
 ```
 
 ---
@@ -438,7 +438,7 @@ GET /api/analytics
 #### JavaScript/TypeScript
 ```typescript
 class ClaudeMarketplaceAPI {
-  private baseURL = 'https://claude-marketplace.github.io/aggregator';
+  private baseURL = 'https://shrwnsan.github.io/claude-marketplace-registry';
 
   async getMarketplaces(): Promise<Marketplace[]> {
     const response = await fetch(`${this.baseURL}/data/marketplaces.json`);
@@ -467,7 +467,7 @@ import requests
 from typing import List, Dict, Any
 
 class ClaudeMarketplaceAPI:
-    def __init__(self, base_url: str = "https://claude-marketplace.github.io/aggregator"):
+    def __init__(self, base_url: str = "https://shrwnsan.github.io/claude-marketplace-registry"):
         self.base_url = base_url
 
     def get_marketplaces(self) -> List[Dict[str, Any]]:
@@ -553,7 +553,7 @@ class ClaudeMarketplaceAPI:
 #### Contact Information
 - **GitHub Issues**: [Report Issues](https://github.com/claude-marketplace/aggregator/issues)
 - **Discussions**: [Ask Questions](https://github.com/claude-marketplace/aggregator/discussions)
-- **Documentation**: [View Docs](https://claude-marketplace.github.io/aggregator/docs)
+- **Documentation**: [View Docs](https://shrwnsan.github.io/claude-marketplace-registry/docs)
 
 ### Error Messages
 

--- a/docs/plans/eval-001-workflow-health-report-20250117.md
+++ b/docs/plans/eval-001-workflow-health-report-20250117.md
@@ -75,17 +75,17 @@ A comprehensive health check of all GitHub Actions workflows reveals significant
 **Likely Root Cause**:
 ```yaml
 # Lines 22-23 in monitoring.yml
-HEALTH_CHECK_URL: https://claude-marketplace.github.io/aggregator/api/health
-STATUS_CHECK_URL: https://claude-marketplace.github.io/aggregator/api/status
+HEALTH_CHECK_URL: https://shrwnsan.github.io/claude-marketplace-registry/api/health
+STATUS_CHECK_URL: https://shrwnsan.github.io/claude-marketplace-registry/api/status
 ```
 
-The workflow is checking health endpoints at `claude-marketplace.github.io/aggregator`, but this repository is `claude-marketplace-registry`. These URLs likely don't exist or are incorrect.
+The workflow is checking health endpoints at `shrwnsan.github.io/claude-marketplace-registry`, but this repository is `claude-marketplace-registry`. These URLs likely don't exist or are incorrect.
 
 **Recommended Actions**:
 - [x] Verify correct health check URLs for this repository — confirmed checking wrong repository URLs
 - [x] Update or disable health endpoint checks — workflow disabled, then workflow file removed entirely
 - [x] Consider disabling until correct endpoints are available — workflow removed (file no longer exists)
-- [x] Alternative: Check if these are meant for a different repository — confirmed, was for `claude-marketplace.github.io/aggregator`, not this repo
+- [x] Alternative: Check if these are meant for a different repository — confirmed, was for `shrwnsan.github.io/claude-marketplace-registry`, not this repo
 
 ---
 

--- a/docs/ref/DEPLOYMENT-SUMMARY.md
+++ b/docs/ref/DEPLOYMENT-SUMMARY.md
@@ -37,7 +37,7 @@
 - **Build Optimization**: Production-ready Next.js build with optimizations
 - **Static File Generation**: Complete build output ready for deployment
 - **API Testing**: All endpoints functional and tested
-- **GitHub Pages Ready**: Deployment configuration verified
+- **GitHub Pages Workflow**: Deploy workflow fixed (PR #98) - awaiting manual Pages configuration in repo settings
 
 ### ✅ **5. Documentation & Quality**
 - **Deployment Runbook**: Step-by-step deployment instructions
@@ -69,8 +69,8 @@
 - **Mobile Responsive**: Optimized for all device types and accessibility
 
 ### **Production Readiness**
-- ✅ **Static Hosting**: GitHub Pages compatible deployment
-- ✅ **Automated Deployment**: CI/CD pipeline for zero-downtime deployments
+- ✅ **Static Hosting**: GitHub Pages compatible deployment (workflow ready, awaiting Pages config)
+- ✅ **Automated Deployment**: CI/CD pipeline with fixed deploy dependency chain (PR #98)
 - ✅ **Monitoring**: Real-time system health and performance alerting
 - ✅ **Backup**: Automated data protection and disaster recovery
 - ✅ **Scalability**: Horizontal scaling with efficient resource utilization

--- a/docs/ref/DEVELOPER_API.md
+++ b/docs/ref/DEVELOPER_API.md
@@ -21,7 +21,7 @@ The Claude Marketplace Aggregator provides a comprehensive REST API for accessin
 
 ### Base URL
 ```
-https://claude-marketplace.github.io/aggregator
+https://shrwnsan.github.io/claude-marketplace-registry
 ```
 
 ### Authentication
@@ -656,7 +656,7 @@ yarn add @claude-marketplace/sdk
 import { ClaudeMarketplaceAPI } from '@claude-marketplace/sdk';
 
 const api = new ClaudeMarketplaceAPI({
-  baseURL: 'https://claude-marketplace.github.io/aggregator',
+  baseURL: 'https://shrwnsan.github.io/claude-marketplace-registry',
   timeout: 10000,
   retries: 3
 });
@@ -695,7 +695,7 @@ pip install claude-marketplace-sdk
 from claude_marketplace import ClaudeMarketplaceAPI
 
 api = ClaudeMarketplaceAPI(
-    base_url="https://claude-marketplace.github.io/aggregator"
+    base_url="https://shrwnsan.github.io/claude-marketplace-registry"
 )
 
 # Get marketplaces
@@ -735,7 +735,7 @@ import (
 )
 
 func main() {
-    api := claudeMarketplace.NewAPI("https://claude-marketplace.github.io/aggregator")
+    api := claudeMarketplace.NewAPI("https://shrwnsan.github.io/claude-marketplace-registry")
 
     // Get marketplaces
     marketplaces, err := api.GetMarketplaces(&claudeMarketplace.GetMarketplacesOptions{
@@ -822,7 +822,7 @@ function verifyWebhookSignature(payload: string, signature: string, secret: stri
 ```typescript
 async function getAllMarketplaces() {
   const response = await fetch(
-    'https://claude-marketplace.github.io/aggregator/data/marketplaces.json'
+    'https://shrwnsan.github.io/claude-marketplace-registry/data/marketplaces.json'
   );
 
   const data = await response.json();
@@ -847,7 +847,7 @@ async function searchPlugins(query: string, category?: string) {
   }
 
   const response = await fetch(
-    `https://claude-marketplace.github.io/aggregator/data/plugins.json?${params}`
+    `https://shrwnsan.github.io/claude-marketplace-registry/data/plugins.json?${params}`
   );
 
   const data = await response.json();
@@ -862,7 +862,7 @@ const databasePlugins = await searchPlugins('postgresql', 'Database');
 ```typescript
 async function getSystemHealth() {
   const response = await fetch(
-    'https://claude-marketplace.github.io/aggregator/api/health'
+    'https://shrwnsan.github.io/claude-marketplace-registry/api/health'
   );
 
   const health = await response.json();
@@ -1007,7 +1007,7 @@ async function exportToPrometheus() {
 
 The complete OpenAPI 3.0 specification is available at:
 ```
-https://claude-marketplace.github.io/aggregator/api/openapi.json
+https://shrwnsan.github.io/claude-marketplace-registry/api/openapi.json
 ```
 
 ### Interactive Documentation
@@ -1037,7 +1037,7 @@ https://claude-marketplace.github.io/aggregator/api/openapi.json
 ## Support
 
 ### Getting Help
-- **Documentation**: [Complete API Docs](https://claude-marketplace.github.io/aggregator/docs)
+- **Documentation**: [Complete API Docs](https://shrwnsan.github.io/claude-marketplace-registry/docs)
 - **GitHub Issues**: [Report Issues](https://github.com/claude-marketplace/aggregator/issues)
 - **Discussions**: [Community Forum](https://github.com/claude-marketplace/aggregator/discussions)
 
@@ -1050,6 +1050,6 @@ https://claude-marketplace.github.io/aggregator/api/openapi.json
 
 **Last Updated**: October 17, 2024
 **API Version**: 1.0.0
-**Base URL**: https://claude-marketplace.github.io/aggregator
+**Base URL**: https://shrwnsan.github.io/claude-marketplace-registry
 
 For questions about the API or to report issues, please visit our GitHub repository or join our community discussions.

--- a/docs/ref/DISASTER_RECOVERY.md
+++ b/docs/ref/DISASTER_RECOVERY.md
@@ -101,7 +101,7 @@ This document outlines the comprehensive disaster recovery (DR) procedures for t
 1. **Assess Impact** (Time: 5-15 minutes)
    ```bash
    # Check system status
-   curl https://claude-marketplace.github.io/aggregator/api/status
+   curl https://shrwnsan.github.io/claude-marketplace-registry/api/status
 
    # Verify data integrity
    npm run validate:plugins
@@ -486,10 +486,10 @@ We apologize for any inconvenience.
 
 ```bash
 # System Health Check
-curl https://claude-marketplace.github.io/aggregator/api/health
+curl https://shrwnsan.github.io/claude-marketplace-registry/api/health
 
 # Detailed Status
-curl https://claude-marketplace.github.io/aggregator/api/status
+curl https://shrwnsan.github.io/claude-marketplace-registry/api/status
 
 # Create Backup
 npm run backup backup


### PR DESCRIPTION
- Replace all instances of claude-marketplace.github.io/aggregator with shrwnsan.github.io/claude-marketplace-registry
- Updated docs: USER_GUIDE.md, DEVELOPER_API.md, MAINTENANCE_GUIDE.md, DISASTER_RECOVERY.md, eval reports
- Clarify GitHub Pages workflow status in DEPLOYMENT-SUMMARY.md (workflow fixed in PR #98, config pending)
- Add note about manual Pages configuration requirement