### PR TITLE
fix: enable Next.js static export for GitHub Pages deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,16 @@
 
 const isProd = process.env.NODE_ENV === 'production';
 
+const repoName = process.env.REPOSITORY_NAME || '';
+
 const nextConfig = {
+  // Static export for GitHub Pages
+  output: 'export',
+
+  // Base path for GitHub Pages (repo is served under /<repo-name>/)
+  basePath: repoName ? `/${repoName}` : '',
+  assetPrefix: repoName ? `/${repoName}/` : '',
+
   // Image configuration
   images: {
     unoptimized: true,


### PR DESCRIPTION
Adds `output: 'export'` to `next.config.js` so `next build` produces the `./out` directory that the deploy workflow expects. Also adds `basePath`/`assetPrefix` for correct asset URLs under the `/<repo-name>/` subpath on GitHub Pages.

**Root cause:** The deploy workflow uploads `./out` but `next build` was producing `.next/` (server mode) since static export was never configured.

Co-Authored-By: Oz <oz-agent@warp.dev>