### PR TITLE
fix: prevent deploy job from being skipped due to transitive scan skip

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,7 +106,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: ${{ always() && needs.build.result == 'success' && github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
The optional `scan` job is skipped on normal pushes. The `build` job uses `always()` to run despite this, but GitHub Actions propagates the skipped status transitively — causing `deploy` to be skipped even though `build` succeeds.

Fix: Add `always()` with an explicit `needs.build.result == 'success'` check to break the propagation chain.

Co-Authored-By: Oz <oz-agent@warp.dev>