### PR TITLE
fix: handle EcosystemStatsResponse wrapper in stats.json validation

### DIFF
--- a/scripts/validate-generated-data.ts
+++ b/scripts/validate-generated-data.ts
@@ -299,8 +299,36 @@ class GeneratedDataValidator {
 
   /**
    * Validate stats.json structure
+   *
+   * stats.json is generated in EcosystemStatsResponse format:
+   *   { success: boolean, data: { overview: { totalMarketplaces, totalPlugins, lastUpdated, ... }, ... }, meta: { ... } }
+   * Unwrap the envelope before validating the inner stats object.
    */
   private validateStatsData(data: unknown, errors: string[], warnings: string[]): void {
+    if (!data || typeof data !== 'object') {
+      errors.push('Stats must be an object');
+      return;
+    }
+
+    const obj = data as Record<string, unknown>;
+
+    // Handle EcosystemStatsResponse wrapper format
+    if ('success' in obj && 'data' in obj) {
+      const inner = obj.data as Record<string, unknown> | undefined;
+      if (!inner || typeof inner !== 'object') {
+        errors.push('EcosystemStatsResponse data field must be an object');
+        return;
+      }
+      const overview = inner.overview as Record<string, unknown> | undefined;
+      if (!overview || typeof overview !== 'object') {
+        errors.push('EcosystemStatsResponse data.overview field must be an object');
+        return;
+      }
+      this.validateStatsObject(overview, errors, warnings);
+      return;
+    }
+
+    // Fallback: validate as a flat stats object
     this.validateStatsObject(data, errors, warnings);
   }
 


### PR DESCRIPTION
## Fix: stats.json validation failing in Scan Marketplaces workflow

### Problem
The daily "Scan Marketplaces" workflow has been failing since March 1st. The `validate:data` step rejects `data/generated/stats.json` because it expects `totalMarketplaces`, `totalPlugins`, and `lastUpdated` as top-level fields.

However, `generate-data.ts` writes `stats.json` in `EcosystemStatsResponse` format, where those fields are nested under `data.overview`:
```json
{
  "success": true,
  "data": {
    "overview": {
      "totalMarketplaces": 3,
      "totalPlugins": 178,
      "lastUpdated": "..."
    }
  },
  "meta": { ... }
}
```

### Fix
Updated `validateStatsData` in `scripts/validate-generated-data.ts` to detect the `EcosystemStatsResponse` wrapper (`{ success, data }`) and unwrap through `data.overview` before delegating to `validateStatsObject`. Falls back to flat validation for non-wrapped stats objects (e.g. the `stats` field inside `complete.json`).

### Verification
After this change, `npm run validate:data` passes all 8 files:
```
✅ data/generated/complete.json
✅ data/generated/marketplaces.json
✅ data/generated/plugins.json
✅ data/generated/stats.json
✅ public/data/index.json
✅ public/data/health.json
✅ public/data/status.json
✅ public/data/analytics.json
```

_This PR was generated with [Oz](https://www.warp.dev/oz)._
