### PR TITLE
fix: resolve CI failures in Scan Marketplaces and Dependency Update workflows

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -27,11 +27,14 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Check for outdated dependencies
         id: outdated
         run: |
-          npm outdated --json > outdated.json || echo "outdated=true" >> $GITHUB_OUTPUT
-          if [ -s outdated.json ]; then
+          npm outdated --json > outdated.json || true
+          if [ -s outdated.json ] && [ "$(cat outdated.json)" != "{}" ]; then
             echo "updates_available=true" >> $GITHUB_OUTPUT
           else
             echo "updates_available=false" >> $GITHUB_OUTPUT

--- a/scripts/validate-generated-data.ts
+++ b/scripts/validate-generated-data.ts
@@ -299,8 +299,38 @@ class GeneratedDataValidator {
 
   /**
    * Validate stats.json structure
+   *
+   * Supports both flat stats format and EcosystemStatsResponse wrapper:
+   *   { success: true, data: { overview: { totalMarketplaces, totalPlugins, ... } } }
    */
   private validateStatsData(data: unknown, errors: string[], warnings: string[]): void {
+    if (!data || typeof data !== 'object') {
+      errors.push('Stats must be an object');
+      return;
+    }
+
+    const obj = data as Record<string, unknown>;
+
+    // Check for EcosystemStatsResponse wrapper format
+    if ('success' in obj && 'data' in obj) {
+      if (typeof obj.success !== 'boolean') {
+        errors.push('EcosystemStatsResponse success must be a boolean');
+      }
+      if (!obj.data || typeof obj.data !== 'object') {
+        errors.push('EcosystemStatsResponse data must be an object');
+        return;
+      }
+      const dataObj = obj.data as Record<string, unknown>;
+      if (!dataObj.overview || typeof dataObj.overview !== 'object') {
+        errors.push('EcosystemStatsResponse data.overview must be an object');
+        return;
+      }
+      // Validate the overview fields as stats
+      this.validateStatsObject(dataObj.overview, errors, warnings);
+      return;
+    }
+
+    // Flat stats format
     this.validateStatsObject(data, errors, warnings);
   }
 


### PR DESCRIPTION
## Summary

Fixes two recurring CI workflow failures:

### 1. Scan Marketplaces — "Generate Data Files" step failure
**Root cause:** `validate:data` fails on `data/generated/stats.json` because the generator writes it in `EcosystemStatsResponse` wrapper format (`{ success, data: { overview: { totalMarketplaces, ... } } }`), but the validator expected flat stats fields at the top level.

**Fix:** Updated `validateStatsData()` in `scripts/validate-generated-data.ts` to detect and unwrap the `EcosystemStatsResponse` format, validating `data.overview` fields.

### 2. Dependency Update — "Update Dependencies" step failure
**Root cause:** Missing `npm ci` before `npm test` / `npm run build`. Also, the `npm outdated` error handling was broken (non-zero exit code when packages are outdated was not properly suppressed).

**Fix:** Added `npm ci` step and fixed the outdated check condition logic.

### Verification
- `npm run validate:data` — ✅ all 8 files pass
- `npm test` — ✅ 263 tests pass
- `npm run build` — ✅ builds successfully

### Not included
- `next-env.d.ts` quote style change (auto-generated by Next.js, cosmetic only) — discarded

### Related CI runs
- https://github.com/shrwnsan/claude-marketplace-registry/actions/runs/23138295009
- https://github.com/shrwnsan/claude-marketplace-registry/actions/runs/23125364959
- https://github.com/shrwnsan/claude-marketplace-registry/actions/runs/22847800529