### PR TITLE
fix: address code review findings

### DIFF
--- a/pages/marketplaces/[id].tsx
+++ b/pages/marketplaces/[id].tsx
@@ -45,7 +45,7 @@ const MarketplaceDetailPage: React.FC = () => {
   const [userRating, setUserRating] = useState(0);
 
   // Get real marketplace data
-  const { data: marketplaceData } = useRealMarketplaceData();
+  const { data: marketplaceData, loading } = useRealMarketplaceData();
 
   // Find marketplace by ID
   const marketplace = useMemo(() => {
@@ -195,6 +195,19 @@ const MarketplaceDetailPage: React.FC = () => {
       copyToClipboard(window.location.href);
     }
   };
+
+  if (loading || !id) {
+    return (
+      <MainLayout>
+        <div className='min-h-screen flex items-center justify-center'>
+          <div className='text-center'>
+            <div className='animate-spin w-8 h-8 border-2 border-primary-500 border-t-transparent rounded-full mx-auto mb-4' />
+            <p className='text-gray-500 dark:text-gray-400'>Loading marketplace...</p>
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
 
   if (!marketplace) {
     return (

--- a/pages/marketplaces/[id].tsx
+++ b/pages/marketplaces/[id].tsx
@@ -54,24 +54,24 @@ const MarketplaceDetailPage: React.FC = () => {
   }, [id, marketplaceData]);
 
   // Get plugins for this marketplace
-  const marketplacePlugins = useMemo(() => {
+  const marketplacePlugins = useMemo((): MarketplacePlugin[] => {
     if (!marketplace) return [];
     if (!marketplace.manifest || !marketplace.manifest.plugins) return [];
 
     // Transform manifest plugins to MarketplacePlugin format
-    return marketplace.manifest.plugins.map((plugin: any) => ({
-      id: plugin.name,
-      name: plugin.name,
-      description: plugin.description || '',
-      category: plugin.category || 'development',
-      tags: [plugin.category || 'development'],
-      author: plugin.author || marketplace.name,
+    return marketplace.manifest.plugins.map((plugin: Record<string, unknown>) => ({
+      id: String(plugin.name),
+      name: String(plugin.name),
+      description: String(plugin.description || ''),
+      category: String(plugin.category || 'development'),
+      tags: [String(plugin.category || 'development')],
+      author: String(plugin.author || marketplace.name),
       authorUrl: `https://github.com/${marketplace.name}`,
       repositoryUrl: marketplace.url,
       stars: marketplace.stars,
       downloads: 0,
       lastUpdated: marketplace.updatedAt,
-      version: plugin.version || '1.0.0',
+      version: String(plugin.version || '1.0.0'),
       license: marketplace.license,
       marketplace: marketplace.name,
       marketplaceUrl: marketplace.url,
@@ -82,7 +82,7 @@ const MarketplaceDetailPage: React.FC = () => {
 
   // Filter and sort plugins
   const filteredPlugins = useMemo(() => {
-    const filtered = marketplacePlugins.filter((plugin: any) => {
+    const filtered = marketplacePlugins.filter((plugin) => {
       const matchesSearch =
         searchQuery === '' ||
         plugin.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -96,7 +96,7 @@ const MarketplaceDetailPage: React.FC = () => {
     });
 
     // Sort plugins
-    filtered.sort((a: any, b: any) => {
+    filtered.sort((a, b) => {
       switch (sortBy) {
         case 'name':
           return a.name.localeCompare(b.name);
@@ -115,7 +115,7 @@ const MarketplaceDetailPage: React.FC = () => {
   // Get unique categories from plugins
   const categories = useMemo((): string[] => {
     const uniqueCats = new Set<string>(
-      marketplacePlugins.map((p: any) => p.category).filter((cat: any) => cat)
+      marketplacePlugins.map((p) => p.category).filter((cat): cat is string => Boolean(cat))
     );
     const cats = ['All', ...Array.from(uniqueCats)];
     return cats;
@@ -126,14 +126,10 @@ const MarketplaceDetailPage: React.FC = () => {
     if (!marketplace) return { totalDownloads: 0, totalStars: 0, verifiedPlugins: 0 };
 
     return {
-      totalDownloads: marketplacePlugins.reduce(
-        (sum: number, plugin: any) => sum + plugin.downloads,
-        0
-      ),
+      totalDownloads: marketplacePlugins.reduce((sum, plugin) => sum + plugin.downloads, 0),
       totalStars:
-        marketplacePlugins.reduce((sum: number, plugin: any) => sum + plugin.stars, 0) +
-        marketplace.stars,
-      verifiedPlugins: marketplacePlugins.filter((plugin: any) => plugin.verified).length,
+        marketplacePlugins.reduce((sum, plugin) => sum + plugin.stars, 0) + marketplace.stars,
+      verifiedPlugins: marketplacePlugins.filter((plugin) => plugin.verified).length,
     };
   }, [marketplace, marketplacePlugins]);
 
@@ -500,7 +496,7 @@ const MarketplaceDetailPage: React.FC = () => {
           <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
             {filteredPlugins.length > 0 ? (
               <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-                {filteredPlugins.map((plugin: any) => (
+                {filteredPlugins.map((plugin) => (
                   <PluginCard key={plugin.id} plugin={plugin} />
                 ))}
               </div>

--- a/pages/plugins/[id].tsx
+++ b/pages/plugins/[id].tsx
@@ -29,6 +29,7 @@ import {
   ArrowLeft,
 } from 'lucide-react';
 import { mockPlugins, mockMarketplaces } from '@/data/mock-data';
+import { usePluginData } from '@/hooks/usePluginData';
 
 const PluginDetailPage: React.FC = () => {
   const router = useRouter();
@@ -42,10 +43,11 @@ const PluginDetailPage: React.FC = () => {
   const [showFeedbackForm, setShowFeedbackForm] = useState(false);
   const [feedback, setFeedback] = useState({ type: '', message: '' });
 
-  // Find plugin by ID
+  // Find plugin by ID (real data first, fall back to mock)
+  const { plugins: realPlugins, loading: pluginsLoading } = usePluginData();
   const plugin = useMemo(() => {
-    return mockPlugins.find((p) => p.id === id);
-  }, [id]);
+    return realPlugins.find((p) => p.id === id) ?? mockPlugins.find((p) => p.id === id);
+  }, [id, realPlugins]);
 
   // Find marketplace
   const marketplace = useMemo(() => {
@@ -191,6 +193,19 @@ const PluginDetailPage: React.FC = () => {
     if (score >= 50) return { level: 'Fair', color: 'text-yellow-600', bg: 'bg-yellow-100' };
     return { level: 'Poor', color: 'text-red-600', bg: 'bg-red-100' };
   };
+
+  if (pluginsLoading || !id) {
+    return (
+      <MainLayout>
+        <div className='min-h-screen flex items-center justify-center'>
+          <div className='text-center'>
+            <div className='animate-spin w-8 h-8 border-2 border-primary-500 border-t-transparent rounded-full mx-auto mb-4' />
+            <p className='text-gray-500 dark:text-gray-400'>Loading plugin...</p>
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
 
   if (!plugin || !pluginDetails) {
     return (

--- a/src/components/EcosystemStats/QualityIndicators.tsx
+++ b/src/components/EcosystemStats/QualityIndicators.tsx
@@ -544,8 +544,10 @@ const QualityIndicators: React.FC<QualityIndicatorsProps> = ({
           <div className='text-sm text-gray-600 dark:text-gray-400'>
             <p className='mb-2'>
               <strong>{data?.verification?.verifiedPlugins || 0}</strong> of{' '}
-              <strong>{(data?.verification?.verifiedPlugins || 0) + 100}</strong> plugins are
-              verified
+              <strong>
+                {data?.security?.scannedPlugins || data?.verification?.verifiedPlugins || 0}
+              </strong>{' '}
+              plugins are verified
             </p>
             <p>Verification ensures plugins meet security, quality, and maintenance standards.</p>
           </div>

--- a/src/components/EcosystemStats/QualityIndicatorsDemo.tsx
+++ b/src/components/EcosystemStats/QualityIndicatorsDemo.tsx
@@ -57,13 +57,11 @@ const QualityIndicatorsDemo: React.FC = () => {
   React.useEffect(() => {
     const originalFetch = global.fetch;
 
-    global.fetch = jest.fn().mockImplementation((url) => {
-      if (url.includes('/api/ecosystem-stats?quality')) {
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: () =>
-            Promise.resolve({
+    global.fetch = (url: string | Request | URL, init?: RequestInit): Promise<Response> => {
+      if (url.toString().includes('/api/ecosystem-stats?quality')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
               success: true,
               data: mockQualityData,
               meta: {
@@ -72,22 +70,15 @@ const QualityIndicatorsDemo: React.FC = () => {
                 responseTime: 150,
               },
             }),
-          headers: new Headers(),
-          redirected: false,
-          statusText: 'OK',
-          type: 'basic',
-          url,
-          clone: jest.fn(),
-          body: null,
-          bodyUsed: false,
-          arrayBuffer: jest.fn(),
-          blob: jest.fn(),
-          formData: jest.fn(),
-          text: jest.fn(),
-        });
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        );
       }
-      return originalFetch(url);
-    });
+      return originalFetch(url, init);
+    };
 
     return () => {
       global.fetch = originalFetch;

--- a/src/services/ecosystem-data.ts
+++ b/src/services/ecosystem-data.ts
@@ -571,7 +571,9 @@ export class EcosystemDataService {
       manifestUrl: repo.manifestUrl,
       plugins,
       tags: repoData.topics,
-      verified: repoData.owner.type === 'Organization', // Simple verification heuristic
+      verified:
+        repoData.owner.type === 'Organization' &&
+        (repoData.stargazers_count >= 10 || repoData.forks_count >= 5),
       qualityScore: this.calculateMarketplaceQuality(repoData, plugins),
       lastScanned: new Date().toISOString(),
       addedAt: repoData.created_at,

--- a/src/utils/data-processor.ts
+++ b/src/utils/data-processor.ts
@@ -536,7 +536,7 @@ export class DataProcessor {
   }
 
   /**
-   * Calculate stars from plugins (simplified - would need GitHub API calls)
+   * Estimate stars from quality scores. NOTE: These are estimated values, not from the GitHub API.
    */
   private calculatePluginStars(plugins: Plugin[]): number {
     // Simplified calculation based on quality scores
@@ -551,7 +551,7 @@ export class DataProcessor {
   }
 
   /**
-   * Estimate total downloads across plugins
+   * Estimate downloads from stars. NOTE: These are estimated values, not real download counts.
    */
   private estimateTotalDownloads(plugins: Plugin[]): number {
     return plugins.reduce((sum, p) => sum + this.estimatePluginDownloads(p), 0);

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -51,19 +51,21 @@ export interface ValidationResult {
  * SQL injection patterns
  */
 const SQL_INJECTION_PATTERNS = [
-  /(\b(SELECT|INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|EXEC|UNION|SCRIPT)\b)/gi,
-  /--(?!\w)|\*\/|\/\*(?!\*)|(\bOR\b.*=.*\bOR\b)|(\bAND\b.*=.*\bAND\b)/gi,
-  /(\bWHERE\b.*\bOR\b.*=)|(\bWHERE\b.*\bAND\b.*=)/gi,
-  /[\'"]\s*(OR|AND)\s+[\'"]?\w+[\'"]?\s*=/gi,
-  /(?<![\w-])[<>\"'=;](?![\w-])/g, // Only match special chars not part of words
+  /(\b(SELECT|INSERT|UPDATE|DELETE|DROP)\b\s+.*\b(FROM|INTO|TABLE|DATABASE)\b)/gi,
+  /(--|#|\/\*)\s*$/gm,
+  /(\bUNION\b\s+\bSELECT\b)/gi,
+  /(['"])\s*;\s*(DROP|DELETE|UPDATE|INSERT)/gi,
+  /(['"])\s*;\s*(--)/gi,
 ];
 
 /**
  * Command injection patterns
  */
 const COMMAND_INJECTION_PATTERNS = [
-  /[;&|`$(){}[\]]/g,
-  /\b(rm|mv|cp|cat|ls|ps|kill|chmod|chown|sudo|su|wget|curl|nc|netcat|telnet)\b/gi,
+  /[;&|`]\s*(rm|mv|cp|chmod|chown|sudo|su|wget|curl|nc|netcat)\b/gi,
+  /\$\([^)]+\)/g,
+  /`[^`]+`/g,
+  /\b(rm|sudo)\s+-rf\b/gi,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Remove `jest.fn()` from production QualityIndicatorsDemo component (guaranteed runtime crash)
- Add loading states to marketplace and plugin detail pages (flash of 404)
- Use real plugin data in plugin detail page instead of mock-only lookup
- Replace hardcoded +100 in verification count with `scannedPlugins` from data
- Add minimum activity threshold (10 stars or 5 forks) for marketplace verification
- Reduce false positives in SQL/command injection detection patterns
- Clarify that synthetic star/download metrics are estimates
- Replace `any` types with proper typing in marketplace detail page

## Test plan
- [x] `npm test` — 263 tests pass, 15 suites, 0 failures
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [ ] Navigate to `/marketplaces/[id]` — shows loading spinner, not 404 flash
- [ ] Navigate to `/plugins/[id]` — shows loading spinner, not 404 flash
- [ ] QualityIndicatorsDemo does not crash when imported

## Out of scope (follow-up)
- Consolidating 3x PerformanceMonitor implementations (~870 lines duplication)
- Consolidating 3x analytics/tracking systems (~1100 lines duplication)
- CSP improvements (limited by Next.js static export mode)
- Populating `manifest.plugins` in the data generation pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)